### PR TITLE
Improvements

### DIFF
--- a/lib/logstash/inputs/cloudflare.rb
+++ b/lib/logstash/inputs/cloudflare.rb
@@ -69,7 +69,7 @@ class LogStash::Inputs::Cloudflare < LogStash::Inputs::Base
   config :auth_key, validate: :string, required: true
   config :domain, validate: :string, required: true
   config :metadata_filepath,
-         validate: :string, default: '/tmp/cf_logstash_metadata.json', required: false
+         validate: :string, default: '/var/lib/logstash/cf_metadata.json', required: false
   config :poll_time, validate: :number, default: 15, required: false
   config :poll_interval, validate: :number, default: 60, required: false
   config :start_from_secs_ago, validate: :number, default: 1200, required: false

--- a/logstash-input-cloudflare.gemspec
+++ b/logstash-input-cloudflare.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-cloudflare'
-  s.version = '0.9.2'
+  s.version = '0.9.3'
   s.licenses = ['Apache License (2.0)']
   s.summary = 'This logstash input plugin fetches logs from Cloudflare using'\
               'their API'

--- a/logstash.conf.m4
+++ b/logstash.conf.m4
@@ -31,7 +31,7 @@ output {
 }
 filter {
  ruby {
-   code => "event['timestamp_ms'] = event['timestamp'] / 1_000_000"
+   code => "event['timestamp'] /= 1_000_000"
  }
  ruby {
    code => "event['edge_requestTime'] = (event['edge_endTimestamp'] - event['edge_startTimestamp']).to_f / 1_000_000_000"

--- a/logstash.conf.m4
+++ b/logstash.conf.m4
@@ -31,7 +31,7 @@ output {
 }
 filter {
  ruby {
-   code => "event['timestamp'] /= 1_000_000"
+   code => "event['timestamp_ms'] /= 1_000_000"
  }
  ruby {
    code => "event['edge_requestTime'] = (event['edge_endTimestamp'] - event['edge_startTimestamp']).to_f / 1_000_000_000"

--- a/logstash.conf.m4
+++ b/logstash.conf.m4
@@ -4,6 +4,8 @@ input {
         auth_key => "CF_AUTH_KEY"
         domain => "CF_DOMAIN"
         type => "cloudflare_logs"
+        poll_time => 15
+        poll_interval => 120
         metadata_filepath => "/logstash-input-cloudflare/cf_metadata.json"
         fields => [
           'timestamp', 'zoneId', 'ownerId', 'zoneName', 'rayId', 'securityLevel',
@@ -29,16 +31,16 @@ output {
 }
 filter {
  ruby {
-   code => "event['timestamp'] /= 1_000_000"
+   code => "event['timestamp_ms'] = event['timestamp'] / 1_000_000"
  }
  ruby {
-   code => "event['edge_startTimestamp'] /= 1_000_000"
+   code => "event['edge_requestTime'] = (event['edge_endTimestamp'] - event['edge_startTimestamp']).to_f / 1_000_000_000"
  }
  ruby {
-   code => "event['edge_endTimestamp'] /= 1_000_000"
+   code => "event['edgeResponse_headerBytes'] = event['edgeResponse_bytes'].to_i - event['edgeResponse_bodyBytes'].to_i"
  }
  date {
-   match => [ "timestamp", "UNIX_MS" ]
+   match => [ "timestamp_ms", "UNIX_MS" ]
  }
  geoip {
    source => "client_ip"


### PR DESCRIPTION
This PR addresses some issue I had with the plugin.
- /tmp is not really great place for storing state information - it's common to clean up this directory regularly and during server reboots. Logstash installation creates /var/lib/logstash which IMO is much better place for cf_metadata.json
- If you have lots of log entries, getting events for last 120 seconds is way too much and will cause logstash app to run out of memory. I kept 120 as default value, and made it possible to change this value (poll_interval parameter). This is workaround fix for https://github.com/iserko/logstash-input-cloudflare/issues/2
- Timestamps on CloudFlare logs are nanoseconds, and de facto for timestamps is seconds. My suggestion is to communicate this on the variable name (timestamp_ms). Also I didn't see any reason to convert edge start and end timestamps to milliseconds - you just lose information on this conversion.
- Something that I find useful information is request time to client. I added this field, and made it seconds so we have same unit with standard web servers (nginx, apache). This could be also an example at README.md.
- Also header size in bytes is something I think is useful information. I added calculations for this. This could be also an example at README.md
- Bumped version number on .gemspec to 0.9.3 (not sure if I should do this on the PR)

Please let me know if there is something you would like to change in this PR and I can do that.
