### PR TITLE
Update logstash-input-cloudflare.gemspec

### DIFF
--- a/logstash-input-cloudflare.gemspec
+++ b/logstash-input-cloudflare.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |s|
   s.metadata = { 'logstash_plugin' => 'true', 'logstash_group' => 'input' }
 
   # Gem dependencies
-  s.add_runtime_dependency 'logstash-core', '>= 2.0.0', '< 3.0.0'
-  s.add_runtime_dependency 'logstash-codec-json', '>= 2.0.0', '< 3.0.0'
+  s.add_runtime_dependency 'logstash-core', '>= 2.0.0', '< 6.0.0'
+  s.add_runtime_dependency 'logstash-codec-json', '>= 2.0.0', '< 6.0.0'
   s.add_development_dependency 'logstash-devutils', '>= 0.0.16', '< 0.1.0'
   s.add_development_dependency 'webmock', '>= 1.24.2', '< 1.25.0'
   s.add_development_dependency 'rubocop', '>= 0.36.0', '< 0.40.0'


### PR DESCRIPTION
was not able to install gem without this changes.
I use logstash version 5.4.3 and installation was failed because of unsatisfied dependencies
Both puppet and manual installations were unsuccessful.